### PR TITLE
Set up CTS templating for Part 13

### DIFF
--- a/cts-config.hcl
+++ b/cts-config.hcl
@@ -1,0 +1,50 @@
+log_level   = "INFO"
+working_dir = "sync-tasks"
+port        = 8558
+
+syslog {}
+
+buffer_period {
+  enabled = true
+  min     = "5s"
+  max     = "20s"
+}
+
+consul {
+  address = "https://consul-server:8501"
+  tls {
+    enabled = true
+    verify  = false
+  }
+  service_registration {
+    enabled      = true
+    service_name = "Consul-Terraform-Sync"
+    default_check {
+      enabled = true
+      address = "http://consul-terraform-sync:8558"
+    }
+  }
+}
+
+driver "terraform" {
+  log         = false
+  persist_log = true
+  backend "local" {}
+}
+
+terraform_provider "aws" {
+  region = "us-east-1"
+}
+
+task {
+  name           = "api"
+  description    = "Task to configure an AWS ALB for the API service"
+  module         = "github.com/jcolemorrison/getting-into-consul//cts_module"
+  providers      = ["aws"]
+  variable_files = ["terraform.tfvars"]
+
+  condition "services" {
+    names      = ["api"]
+    datacenter = "dc1"
+  }
+}

--- a/cts_module/fixtures/services.tfvars
+++ b/cts_module/fixtures/services.tfvars
@@ -1,0 +1,25 @@
+services = {
+  "web.service-2.dc1" : {
+    id              = "web"
+    name            = "web"
+    address         = "172.19.0.5"
+    port            = 9002
+    meta            = {}
+    tags            = []
+    namespace       = null
+    status          = "passing"
+    node            = "service-2"
+    node_id         = "fe3d73af-e099-941c-acfb-93ef5596e01f"
+    node_address    = "172.19.0.5"
+    node_datacenter = "dc1"
+    node_tagged_addresses = {
+      lan      = "172.19.0.5"
+      lan_ipv4 = "172.19.0.5"
+      wan      = "172.19.0.5"
+      wan_ipv4 = "172.19.0.5"
+    }
+    node_meta = {
+      consul-network-segment = ""
+    }
+  }
+}

--- a/cts_module/main.tf
+++ b/cts_module/main.tf
@@ -1,0 +1,93 @@
+resource "aws_security_group" "alb" {
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "Allow traffic to load balancer"
+    from_port   = var.load_balancer_port
+    to_port     = var.load_balancer_port
+    protocol    = "tcp"
+    cidr_blocks = var.load_balancer_allow_cidr_blocks
+  }
+
+  tags = var.tags
+}
+
+resource "aws_security_group_rule" "lb_to_app" {
+  type                     = "ingress"
+  from_port                = local.application_port
+  to_port                  = local.application_port
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+  security_group_id        = var.application_security_group_id
+}
+
+resource "aws_lb" "cts" {
+  name               = var.name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.subnet_ids
+
+  enable_deletion_protection = false
+
+  tags = var.tags
+}
+
+resource "aws_lb_listener" "cts" {
+  load_balancer_arn = aws_lb.cts.arn
+  port              = var.load_balancer_port
+  protocol          = var.load_balancer_protocol
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Fixed response content"
+      status_code  = "200"
+    }
+  }
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = local.application_name
+  port        = local.application_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled = true
+    path    = local.application_health_check_path
+  }
+}
+
+resource "aws_lb_target_group_attachment" "app" {
+  for_each          = local.ip_addresses
+  target_group_arn  = aws_lb_target_group.app.arn
+  target_id         = each.value
+  port              = local.application_port
+  availability_zone = "all"
+}
+
+resource "aws_lb_listener_rule" "app" {
+  listener_arn = aws_lb_listener.cts.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/${var.application_name}/*"]
+    }
+  }
+}

--- a/cts_module/providers.tf
+++ b/cts_module/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.17"
+    }
+  }
+}

--- a/cts_module/variables.tf
+++ b/cts_module/variables.tf
@@ -1,0 +1,79 @@
+variable "services" {
+  description = "Consul services monitored by Consul-Terraform-Sync"
+  type = map(
+    object({
+      id        = string
+      name      = string
+      kind      = string
+      address   = string
+      port      = number
+      meta      = map(string)
+      tags      = list(string)
+      namespace = string
+      status    = string
+
+      node                  = string
+      node_id               = string
+      node_address          = string
+      node_datacenter       = string
+      node_tagged_addresses = map(string)
+      node_meta             = map(string)
+
+      cts_user_defined_meta = map(string)
+    })
+  )
+}
+
+variable "name" {
+  type        = string
+  description = "Name of resources for this CTS module"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs to attach to load balancer"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID for application target group"
+}
+
+variable "application_security_group_id" {
+  type        = string
+  description = "Security Group ID for application to allow load balancer access"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "List of tags for all resources"
+  default = {
+    "Purpose" = "getting-into-consul"
+    "Module"  = "cts_module"
+  }
+}
+
+variable "load_balancer_port" {
+  type        = number
+  description = "Load balancer port for clients to access"
+  default     = 80
+}
+
+variable "load_balancer_protocol" {
+  type        = string
+  description = "Load balancer protocol for clients to access"
+  default     = "HTTP"
+}
+
+variable "load_balancer_allow_cidr_blocks" {
+  type        = list(string)
+  description = "Load balancer CIDR blocks to allow"
+  default     = ["0.0.0.0/0"]
+}
+
+locals {
+  application_port              = 9090
+  application_health_check_path = ""
+  application_name              = "example"
+  ip_addresses                  = toset([])
+}


### PR DESCRIPTION
Set up initial CTS configuration and module for security group + application load balancer in Part 13. While not fully tested, this should provide a starting point for updates and re-focus the stream on CTS (and not so much on building a Terraform module).